### PR TITLE
Added LruCache, which is dependent on android-support-v4.jar.

### DIFF
--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -4,12 +4,15 @@
     xmlns:ctc="http://schemas.android.com/apk/res/com.ctc.android.widget"
     android:orientation="vertical"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    >
+    android:layout_height="fill_parent">
+
 	<com.ctc.android.widget.ImageMap  
 	    android:id="@+id/map"
     	android:layout_width="fill_parent" 
-    	android:layout_height="fill_parent" 
-    	android:src="@drawable/usamap"
-    	ctc:map="usamap"/>
+    	android:layout_height="fill_parent"
+    	ctc:map="usamap"
+        ctc:maxSizeFactor="1.5"
+        ctc:scaleFromOriginal="true"
+        ctc:fitImageToScreen="true"/>
+
 </LinearLayout>

--- a/src/com/ctc/android/widget/BitmapHelper.java
+++ b/src/com/ctc/android/widget/BitmapHelper.java
@@ -1,0 +1,71 @@
+package com.ctc.android.widget;
+
+import android.graphics.Bitmap;
+import android.support.v4.util.LruCache;
+import android.util.Log;
+
+/**
+ * This class helps caching images for faster loading on second activity open.
+ * May also be used at startup to load all images into memory.
+ * Created by fess on 2/6/14.
+ *
+ * The implementation is taken from the official manual:
+ * @link http://developer.android.com/training/displaying-bitmaps/cache-bitmap.html
+ *
+ * TODO: implement asynchronous image loading.
+ * TODO: configurable cache size.
+ *
+ */
+public class BitmapHelper
+{
+	private LruCache<String, Bitmap> mMemoryCache;
+
+	public static BitmapHelper instance;
+
+	public static BitmapHelper getInstance()
+	{
+		if (null == instance)
+		{
+			instance = new BitmapHelper();
+		}
+		return instance;
+	}
+
+	private BitmapHelper()
+	{
+		//trying to implement image caching
+		// Get max available VM memory, exceeding this amount will throw an
+		// OutOfMemory exception. Stored in kilobytes as LruCache takes an
+		// int in its constructor.
+		final int maxMemory = (int) (Runtime.getRuntime().maxMemory() / 1024);
+
+		// Use 1/2nd of the available memory for this memory cache.
+		final int cacheSize = maxMemory / 2;
+
+		mMemoryCache = new LruCache<String, Bitmap>(cacheSize)
+		{
+			@Override
+			protected int sizeOf(String key, Bitmap bitmap)
+			{
+				// The cache size will be measured in kilobytes rather than
+				// number of items.
+				return bitmap.getRowBytes()*bitmap.getHeight() / 1024;
+			}
+		};
+	}
+
+	public void addBitmapToMemoryCache(String key, Bitmap bitmap)
+	{
+		if (getBitmapFromMemCache(key) == null)
+		{
+			Log.e("Bitmap Helper", "Putting bitmap to cache for key: " + key);
+			mMemoryCache.put(key, bitmap);
+		}
+	}
+
+	public Bitmap getBitmapFromMemCache(String key)
+	{
+		Log.e("Bitmap Helper", "Loading bitmap from cache for key: " + key);
+		return mMemoryCache.get(key);
+	}
+}

--- a/src/com/ctc/android/widget/ImageMapTestActivity.java
+++ b/src/com/ctc/android/widget/ImageMapTestActivity.java
@@ -30,6 +30,7 @@ public class ImageMapTestActivity extends Activity {
         
         // find the image map in the view
         mImageMap = (ImageMap)findViewById(R.id.map);
+	    mImageMap.setImageResource(R.drawable.usamap);
         
         // add a click handler to react when areas are tapped
         mImageMap.addOnImageMapClickedHandler(new ImageMap.OnImageMapClickedHandler()


### PR DESCRIPTION
Added LruCache, which is dependent on android-support-v4.jar. 

Modified onScreenTapped: the formula there now depends on if the picture is larger than the screen or not. This actually needs investigation. I've tested it on a Nexus 7 emulator and it worked there, but I'm not sure about devices with different DPI / screen size.

Modified setImageResource() so it would take into account inSampleSize. But the decision mechanism for what inSampleSize to use (default is 1, i.e. no changed to the original image) is still to implement.
